### PR TITLE
docs: redirect the website to the readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## TRANQUIL development version
+
+- Redirect the website to the README. (#8, @kelly-sovacool)
+
 ## TRANQUIL 0.2.0
 
 - Now using a changelog to track user-facing changes.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,8 @@
+<html xmlns="http://www.w3.org/1999/xhtml">    
+  <head>      
+    <title>Redirecting to GitHub</title>      
+    <meta http-equiv="refresh" content="0;URL='https://github.com/CCBR/TRANQUIL/blob/main/README.md'" />    
+  </head>    
+  <body> 
+  </body>  
+</html>  


### PR DESCRIPTION
since we don't have any docs beyond the readme, just redirect the github pages site back to the readme